### PR TITLE
ニュースページへのキャッシュの導入 その1

### DIFF
--- a/pages/news/2025/07/16/1.tsx
+++ b/pages/news/2025/07/16/1.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/07/16/1.tsx
+++ b/pages/news/2025/07/16/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/07/18/1.tsx
+++ b/pages/news/2025/07/18/1.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/07/18/1.tsx
+++ b/pages/news/2025/07/18/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/07/22/1.tsx
+++ b/pages/news/2025/07/22/1.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/07/22/1.tsx
+++ b/pages/news/2025/07/22/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/07/23/1.tsx
+++ b/pages/news/2025/07/23/1.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/07/23/1.tsx
+++ b/pages/news/2025/07/23/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/07/26/1.tsx
+++ b/pages/news/2025/07/26/1.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/07/26/1.tsx
+++ b/pages/news/2025/07/26/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/08/17/1.tsx
+++ b/pages/news/2025/08/17/1.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/08/17/1.tsx
+++ b/pages/news/2025/08/17/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/08/28/1.tsx
+++ b/pages/news/2025/08/28/1.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useEffect, useState } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/08/28/1.tsx
+++ b/pages/news/2025/08/28/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useEffect, useState } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/08/31/1.tsx
+++ b/pages/news/2025/08/31/1.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/08/31/1.tsx
+++ b/pages/news/2025/08/31/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/09/13/1.tsx
+++ b/pages/news/2025/09/13/1.tsx
@@ -7,6 +7,18 @@ import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
 import { company } from '@/utils/version';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/09/13/1.tsx
+++ b/pages/news/2025/09/13/1.tsx
@@ -7,9 +7,9 @@ import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
 import { company } from '@/utils/version';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/09/15/1.tsx
+++ b/pages/news/2025/09/15/1.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/09/15/1.tsx
+++ b/pages/news/2025/09/15/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/09/28/1.tsx
+++ b/pages/news/2025/09/28/1.tsx
@@ -7,6 +7,18 @@ import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
 import { company } from '@/utils/version';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/09/28/1.tsx
+++ b/pages/news/2025/09/28/1.tsx
@@ -7,9 +7,9 @@ import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
 import { company } from '@/utils/version';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/09/28/2.tsx
+++ b/pages/news/2025/09/28/2.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/09/28/2.tsx
+++ b/pages/news/2025/09/28/2.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/09/28/3.tsx
+++ b/pages/news/2025/09/28/3.tsx
@@ -6,6 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/09/28/3.tsx
+++ b/pages/news/2025/09/28/3.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/10/08/1.tsx
+++ b/pages/news/2025/10/08/1.tsx
@@ -7,9 +7,9 @@ import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
 import { company } from '@/utils/version';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/10/08/1.tsx
+++ b/pages/news/2025/10/08/1.tsx
@@ -7,6 +7,18 @@ import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
 import { company } from '@/utils/version';
+import { CacheControlProps } from '@/pages/news';
+
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export const kokuseiChousaStr:string = "国勢調査";
 

--- a/pages/news/2025/11/13/1.tsx
+++ b/pages/news/2025/11/13/1.tsx
@@ -6,7 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
 
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/11/13/1.tsx
+++ b/pages/news/2025/11/13/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/2025/12/14/1.tsx
+++ b/pages/news/2025/12/14/1.tsx
@@ -6,7 +6,18 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
+import { CacheControlProps } from '@/pages/news';
 
+export async function getServerSideProps({ res }: CacheControlProps) {
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=604800, stale-while-revalidate=59'
+    );
+
+    return {
+        props: {},
+    };
+}
 
 export default function NewsPage() {
     const [menuStatus, setMenuStatus] = useState(false);

--- a/pages/news/2025/12/14/1.tsx
+++ b/pages/news/2025/12/14/1.tsx
@@ -6,9 +6,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import { useState, useEffect } from 'react';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
-import { CacheControlProps } from '@/pages/news';
+import { GetServerSideProps } from 'next';
 
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=604800, stale-while-revalidate=59'

--- a/pages/news/index.tsx
+++ b/pages/news/index.tsx
@@ -7,13 +7,9 @@ import RightMenuJp from '@/utils/pageParts/top/jp/RightMenu';
 import HeaderJp from '@/utils/pageParts/top/jp/Header';
 import FooterJp from '@/utils/pageParts/top/jp/Footer';
 import { kokuseiChousaStr } from '@/pages/news/2025/10/08/1';
-import { NextApiResponse } from 'next';
+import { GetServerSideProps } from 'next';
 
-export interface CacheControlProps{
-    res: NextApiResponse;
-}
-
-export async function getServerSideProps({ res }: CacheControlProps) {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
     res.setHeader(
         'Cache-Control',
         'public, s-maxage=300, stale-while-revalidate=59'

--- a/pages/news/index.tsx
+++ b/pages/news/index.tsx
@@ -9,7 +9,7 @@ import FooterJp from '@/utils/pageParts/top/jp/Footer';
 import { kokuseiChousaStr } from '@/pages/news/2025/10/08/1';
 import { NextApiResponse } from 'next';
 
-interface CacheControlProps{
+export interface CacheControlProps{
     res: NextApiResponse;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス改善**
  * ニュースページのサーバーサイドキャッシュ制御を強化し、応答に `Cache-Control` を設定しました。これにより複数のニュース詳細ページでコンテンツ配信が最適化され、表示の待ち時間を短縮します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->